### PR TITLE
Kleine Doku-Anpassungen nach Build-Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 20260329
+- Upgrade auf Gluon v2025.1.x-halle (OpenWrt 24.10, batman-adv 2024.3)
+- Erweiterte Build-Targets bei Freifunk Halle (u.a. RPi 3/4, Qualcomm IPQ807x, Rockchip)
+- GitHub Actions auf Ubuntu 24.04 aktualisiert
+
 ## 20191009
 - Freifunk Halle Firmware 1.0.1, Gluon-Release 2018.2.x, OpenWRT v2018.06-SNAPSHOT r7835+24-89808e211c
 - Den Zeitserver der Physikalisch-Technische-Bundesanstalt eingetragen
@@ -114,4 +119,4 @@ nutzen. ]
 - mac: Macadresse geändert
 - fastd-vpn: zweiten Knoten hinzugefügt
 - autoupdater aktiviert
-- openvpn-polarssl Paket hinzugefügt 
+- openvpn-polarssl Paket hinzugefügt

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Site-Konfiguration für Freifunk Halle basierend auf Gluon v2025.1.x-halle
 Für den Build-Prozess werden folgende Pakete benötigt:
 
 ```bash
-sudo apt install git build-essential libncurses-dev zlib1g-dev gawk gettext libssl-dev xsltproc rsync qemu-utils unzip wget python3
+sudo apt install git build-essential libncurses-dev zlib1g-dev gawk gettext libssl-dev xsltproc rsync qemu-utils unzip wget python3 clang llvm
 ```
 
 ## eigene Images bauen


### PR DESCRIPTION
1. aktuellen Changelog-Eintrag ergänzt
2. In der README `clang` und `llvm` bei den Build-Paketen ergänzt
    - Beim lokalen Test-Build haben genau diese Pakete gefehlt; danach lief der Build durch.